### PR TITLE
Feature/allow authenticated oauth1 calls

### DIFF
--- a/src/OAuth1/AbstractProvider.php
+++ b/src/OAuth1/AbstractProvider.php
@@ -135,21 +135,16 @@ abstract class AbstractProvider extends AbstractBaseProvider
      * @param array $parameters
      * @return \SocialConnect\Common\Http\Response
      */
-    public function oauthRequest($uri, $method = Client::GET, $parameters = [])
+    public function oauthRequest($uri, $method = Client::GET, $parameters = [], $headers = [])
     {
-        $headers = [
+        $headers = array_merge([
             'Accept' => 'application/json'
-        ];
-
-        if (isset($parameters['headers']) && is_Array($parameters['headers'])) {
-            $headers = array_merge($headers, $parameters['headers']);
-            unset($parameters['headers']);
-        }
+        ], $headers);
 
         if ($method == Client::POST) {
             $headers['Content-Type'] = 'application/x-www-form-urlencoded';
         }
-        
+
         $parameters = array_merge(
             [
                 'oauth_version' => '1.0',

--- a/src/OAuth1/AbstractProvider.php
+++ b/src/OAuth1/AbstractProvider.php
@@ -135,7 +135,7 @@ abstract class AbstractProvider extends AbstractBaseProvider
      * @param array $parameters
      * @return \SocialConnect\Common\Http\Response
      */
-    protected function oauthRequest($uri, $method = Client::GET, $parameters = [])
+    public function oauthRequest($uri, $method = Client::GET, $parameters = [])
     {
         $headers = [
             'Accept' => 'application/json'

--- a/src/OAuth1/AbstractProvider.php
+++ b/src/OAuth1/AbstractProvider.php
@@ -141,6 +141,11 @@ abstract class AbstractProvider extends AbstractBaseProvider
             'Accept' => 'application/json'
         ];
 
+        if (isset($parameters['headers']) && is_Array($parameters['headers'])) {
+            $headers = array_merge($headers, $parameters['headers']);
+            unset ($parameters['headers']);
+        }
+
         if ($method == Client::POST) {
             $headers['Content-Type'] = 'application/x-www-form-urlencoded';
         }

--- a/src/OAuth1/AbstractProvider.php
+++ b/src/OAuth1/AbstractProvider.php
@@ -143,7 +143,7 @@ abstract class AbstractProvider extends AbstractBaseProvider
 
         if (isset($parameters['headers']) && is_Array($parameters['headers'])) {
             $headers = array_merge($headers, $parameters['headers']);
-            unset ($parameters['headers']);
+            unset($parameters['headers']);
         }
 
         if ($method == Client::POST) {

--- a/src/OAuth1/AbstractProvider.php
+++ b/src/OAuth1/AbstractProvider.php
@@ -274,4 +274,20 @@ abstract class AbstractProvider extends AbstractBaseProvider
     {
         $this->scope = $scope;
     }
+
+    /**
+     * @param Token $token
+     */
+    public function setConsumerToken(Token $token)
+    {
+        $this->consumerToken = $token;
+    }
+
+    /**
+     * @return \SocialConnect\OAuth1\Token
+     */
+    public function getConsumerToken()
+    {
+        return $this->consumerToken;
+    }
 }


### PR DESCRIPTION
new feature

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/SocialConnect/auth/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

This allows the usage of SocialConnect to make authenticated requests to an OAuth1-secured API. As calling an OAuth1-API involves a bit more than setting an Authentication-header containing a Bearer-Token it was easier to use the features already available here than implementing them a second time.

So with this PR integrated you can then call an API like this:

```php
$service = new Service($httpClient, $session, $config);
$provider = $service->getProvider('atlassian');
// $appSession has been initialized during the login-callback with
// $appSession->token = $provider->getConsumerToken();
$appSession = new \Zend\Session\Container('app');
$provider->setConsumerToken($appSession->token);

$content = $provider->oauthRequest(
            [OAuth1-API-Endpoint],
            'GET',
            ['oauth_token' => $appSession->token->getToken()],
            ['header-key' => 'header-value'] // Optionally add headers
        );
```

