### PR TITLE
Fixed Facebook provider exception when it is parsing token

### DIFF
--- a/src/OAuth2/Provider/Facebook.php
+++ b/src/OAuth2/Provider/Facebook.php
@@ -6,7 +6,9 @@
 
 namespace SocialConnect\OAuth2\Provider;
 
+use SocialConnect\OAuth2\AccessToken;
 use SocialConnect\Provider\AccessTokenInterface;
+use SocialConnect\Provider\Exception\InvalidAccessToken;
 use SocialConnect\Provider\Exception\InvalidResponse;
 use SocialConnect\Common\Entity\User;
 use SocialConnect\Common\Http\Client\Client;

--- a/src/OAuth2/Provider/Facebook.php
+++ b/src/OAuth2/Provider/Facebook.php
@@ -44,6 +44,23 @@ class Facebook extends \SocialConnect\OAuth2\AbstractProvider
     /**
      * {@inheritdoc}
      */
+    public function parseToken($body)
+    {
+        if (empty($body)) {
+            throw new InvalidAccessToken('Provider response with empty body');
+        }
+
+        $result = json_decode($body, true);
+        if ($result) {
+            return new AccessToken($result);
+        }
+
+        throw new InvalidAccessToken('Provider response with not valid JSON');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getIdentity(AccessTokenInterface $accessToken)
     {
         $response = $this->httpClient->request(


### PR DESCRIPTION
Hey!

Type: bug fix
Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/SocialConnect/auth/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.

Small description of change:
Facebook provider generate exception when try parse token.
Thanks :smiley_cat:
