### PR TITLE
Fix setting of Oauth2 access token expiry.

### DIFF
--- a/tests/Test/OAuth2/AccessTokenTest.php
+++ b/tests/Test/OAuth2/AccessTokenTest.php
@@ -31,6 +31,27 @@ class AccessTokenTest extends \Test\TestCase
         return $token;
     }
 
+    public function testConstructSuccessWithExpiresIn()
+    {
+        $expectedToken = "XSFJSKLFJDLKFJDLSJFLDSJFDSLFSD";
+        $expectedExpires = time();
+        $expectedUserId = 123456789;
+
+        $token = new AccessToken(
+            [
+                'access_token' => $expectedToken,
+                'expires_in' => $expectedExpires,
+                'user_id' => $expectedUserId
+            ]
+        );
+
+        $this->assertSame($expectedToken, $token->getToken());
+        $this->assertSame($expectedUserId, $token->getUserId());
+        $this->assertTrue($expectedExpires < $token->getExpires());
+
+        return $token;
+    }
+
     public function testSetUserId()
     {
         $expectedToken = "XSFJSKLFJDLKFJDLSJFLDSJFDSLFSD";


### PR DESCRIPTION
Hey!

Type: bug fix

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/SocialConnect/auth/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:
Currently the access token expiry is not set when using Google provider. That is because google uses param "expires_in" not "expires".  The code changes I have done are based on thephpleague's oauth2-client [access token class](https://github.com/thephpleague/oauth2-client/blob/master/src/Token/AccessToken.php#L79).

Thanks, I hope your macbook is fixed soon. :smiley_cat:
