### PR TITLE
Add paragonie/random_compat as dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
     "require": {
         "php": ">=5.5",
         "ext-json": "*",
-        "socialconnect/common": "^1.0"
+        "socialconnect/common": "^1.0",
+        "paragonie/random_compat": "^2.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "~3.0.1",

--- a/src/OAuth2/AbstractProvider.php
+++ b/src/OAuth2/AbstractProvider.php
@@ -59,34 +59,7 @@ abstract class AbstractProvider extends AbstractBaseProvider
      */
     protected function generateState()
     {
-        if (function_exists('random_bytes')) {
-            return bin2hex(random_bytes(self::STATE_BYTES));
-        }
-
-        if (function_exists('openssl_random_pseudo_bytes')) {
-            $bytes = openssl_random_pseudo_bytes(self::STATE_BYTES, $strongSource);
-            if (!$strongSource) {
-                trigger_error(
-                    'openssl was unable to use a strong source of entropy. ' .
-                    'Consider updating your system libraries, or ensuring ' .
-                    'you have more available entropy.',
-                    E_USER_WARNING
-                );
-            }
-
-            return bin2hex($bytes);
-        }
-
-        trigger_error(
-            'You do not have a safe source of random data available. ' .
-            'Install either the openssl extension, or paragonie/random_compat. ' .
-            'Falling back to an insecure random source.',
-            E_USER_WARNING
-        );
-
-        return md5(
-            time() . mt_rand()
-        );
+        return bin2hex(random_bytes(self::STATE_BYTES));
     }
 
     /**


### PR DESCRIPTION
This provides polyfill for random_bytes() and avoid method existence checks.
Refs #32