### PR TITLE
Return Facebook login profile picture as other providers

### DIFF
--- a/src/OAuth2/Provider/Facebook.php
+++ b/src/OAuth2/Provider/Facebook.php
@@ -88,6 +88,9 @@ class Facebook extends \SocialConnect\OAuth2\AbstractProvider
             );
         }
 
+        $result->picture_object = $result->picture;
+        $result->picture =  $result->picture->data->url;
+
         $hydrator = new ObjectMap(
             [
                 'id' => 'id',


### PR DESCRIPTION
Hey!

Type:  new feature

Link to issue:

- [x ] I have read and understood the [Contributing Guidelines](https://github.com/SocialConnect/auth/blob/master/.github/CONTRIBUTING.md).
- [ x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

Google returns only one simple string with profile picture instead of Facebook wich returns an object.
So i have override "picture" variable in return , and saved the original object into "picture_object" (if you need)

Thanks lamasgergo
