### PR TITLE
Don't start session if using cli or phpdbg.

### DIFF
--- a/src/Provider/Session/Session.php
+++ b/src/Provider/Session/Session.php
@@ -9,7 +9,9 @@ class Session implements SessionInterface
 {
     public function __construct()
     {
-        session_start();
+        if (session_status() == PHP_SESSION_NONE) {
+            session_start();
+        }
     }
 
     /**

--- a/src/Provider/Session/Session.php
+++ b/src/Provider/Session/Session.php
@@ -9,7 +9,7 @@ class Session implements SessionInterface
 {
     public function __construct()
     {
-        if (session_status() == PHP_SESSION_NONE) {
+        if (session_status() === PHP_SESSION_NONE && !(PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg')) {
             session_start();
         }
     }


### PR DESCRIPTION
This prevents PHP for throwing errors when running testsuite.

I am writing tests for my CakePHP plugin and this patch saves me the effort of having to create mocks to avoid the error `session_start(): Cannot send session cookie - headers already sent by` thrown by PHP.