### PR TITLE
Add connector for Meetup

### DIFF
--- a/src/Auth/CollectionFactory.php
+++ b/src/Auth/CollectionFactory.php
@@ -52,6 +52,7 @@ class CollectionFactory implements FactoryInterface
         OAuth2\Provider\LinkedIn::NAME      => OAuth2\Provider\LinkedIn::class,
         OAuth2\Provider\Yahoo::NAME         => OAuth2\Provider\Yahoo::class,
         OAuth2\Provider\WordPress::NAME     => OAuth2\Provider\WordPress::class,
+        OAuth2\Provider\Meetup::NAME        => OAuth2\Provider\Meetup::class,
         // OpenID
         OpenID\Provider\Steam::NAME         => OpenID\Provider\Steam::class,
         // OpenIDConnect

--- a/src/OAuth2/Provider/Meetup.php
+++ b/src/OAuth2/Provider/Meetup.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * SocialConnect project
+ *
+ * @author: Andreas Heigl https://github.com/heiglandreas <andreas@heigl.org>
+ */
+
+namespace SocialConnect\OAuth2\Provider;
+
+use SocialConnect\Common\Http\Client\Client;
+use SocialConnect\Provider\AccessTokenInterface;
+use SocialConnect\Provider\Exception\InvalidAccessToken;
+use SocialConnect\Provider\Exception\InvalidResponse;
+use SocialConnect\Common\Entity\User;
+use SocialConnect\Common\Hydrator\ObjectMap;
+use SocialConnect\OAuth2\AccessToken;
+
+class Meetup extends \SocialConnect\OAuth2\AbstractProvider
+{
+    const NAME = 'meetup';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBaseUri()
+    {
+        return 'https://api.meetup.com/';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAuthorizeUri()
+    {
+        return 'https://secure.meetup.com/oauth2/authorize';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRequestTokenUri()
+    {
+        return 'https://secure.meetup.com/oauth2/access';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return self::NAME;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function parseToken($body)
+    {
+        $result = json_decode($body, true);
+        if ($result) {
+            return new AccessToken($result);
+        }
+
+        throw new InvalidAccessToken('AccessToken is not a valid JSON');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIdentity(AccessTokenInterface $accessToken)
+    {
+        $response = $this->httpClient->request(
+            $this->getBaseUri() . '2/member/self?sign=true&photo-host=public&fields=gender',
+            [
+                'format' => 'json'
+            ],
+            Client::GET,
+            [
+                'Authorization' => 'Bearer ' . $accessToken->getToken(),
+            ]
+        );
+
+        if (!$response->isSuccess()) {
+            throw new InvalidResponse(
+                'API response with error code',
+                $response
+            );
+        }
+
+        $result = $response->json();
+        if (!$result) {
+            throw new InvalidResponse(
+                'API response is not a valid JSON object',
+                $response
+            );
+        }
+
+        $user = new User();
+
+        $user->id         = $result->id;
+        $user->username   = $result->name;
+        $user->fullname   = $result->name;
+        $user->sex        = $result->gender;
+        $user->pictureURL = $result->photo->photo_link;
+
+        return $user;
+    }
+}

--- a/tests/Test/OAuth2/Provider/MeetupTest.php
+++ b/tests/Test/OAuth2/Provider/MeetupTest.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * SocialConnect project
+ * @author: Andreas Heigl https://github.com/heiglandreas <andreas@heigl.org>
+ */
+
+namespace Test\OAuth2\Provider;
+
+class MeetupTest extends AbstractProviderTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getProviderClassName()
+    {
+        return \SocialConnect\OAuth2\Provider\Meetup::class;
+    }
+}


### PR DESCRIPTION
Type: new feature

Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/SocialConnect/auth/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR. (OK. It's only one)

Small description of change:

This PR adds a connector that allows to authenticate against the Meetup-API.

Creating an OAuth-Consumer under https://www.meetup.com/meetup_api/oauth_consumers/ is necessary


