### PR TITLE
Feature(CI): Migrate to new Scrutinizer engine

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -2,6 +2,13 @@
 before_commands:
     - "composer install --no-dev --prefer-source"
 
+build:
+    nodes:
+        analysis:
+            tests:
+                override:
+                    - php-scrutinizer-run
+
 tools:
     external_code_coverage:
         timeout: 600


### PR DESCRIPTION
https://scrutinizer-ci.com/docs/tools/php/php-analyzer/guides/migrate_to_new_php_analysis


Hey!

Type: bug fix | new feature | code quality | documentation

Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [ ] I have read and understood the [Contributing Guidelines](https://github.com/SocialConnect/auth/blob/master/.github/CONTRIBUTING.md).
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

Thanks :smiley_cat:
