### PR TITLE
Bump up phpstan checks to level 4.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,7 @@ phpstan:
   image: registry.gitlab.com/socialconnect-php/auth:7.3
   script:
     - composer install -o
-    - ./vendor/bin/phpstan.phar analyse src/ tests/ --no-progress --level 2
+    - ./vendor/bin/phpstan.phar analyse src/ tests/ --no-progress
   tags:
     - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
-
 dist: trusty
 sudo: false
+
+env:
+  global:
+    - DEFAULT=1
 
 language: php
 
@@ -9,18 +12,31 @@ php:
   - 7.2
   - 7.3
 
+matrix:
+  fast_finish: true
+
+  include:
+    - php: 7.3
+      env: DEFAULT=0 STATIC_ANALYSIS=1
+
+    - php: 7.3
+      env: DEFAULT=0 PHPCS=1
+
 install:
-  - composer self-update
   - composer --prefer-dist install
 
 script:
-  - ./vendor/bin/phpcs --standard=PSR2 --report=emacs --extensions=php --warning-severity=0 src/ tests/Test
-  - 'if [ {$TRAVIS_PHP_VERSION} = "7.3" ]; then
-      ./vendor/bin/phpunit --process-isolation -v --debug --coverage-clover=coverage.clover;
-    else
-      ./vendor/bin/phpunit -v --debug --no-coverage;
-    fi'
+  - if [[ $DEFAULT == 1 && $TRAVIS_PHP_VERSION == "7.3" ]]; then vendor/bin/phpunit --process-isolation -v --debug --coverage-clover=coverage.clover; fi
+  - if [[ $DEFAULT == 1 && $TRAVIS_PHP_VERSION != "7.3" ]]; then vendor/bin/phpunit -v --debug --no-coverage; fi
+  - if [[ $PHPCS == 1 ]]; then vendor/bin/phpcs --standard=PSR2 --report=emacs --extensions=php --warning-severity=0 src/ tests/Test; fi
+  - if [[ $STATIC_ANALYSIS == 1 ]]; then vendor/bin/phpstan.phar analyse src/ tests/; fi
 
 after_script:
-  - if [ "$TRAVIS_PHP_VERSION" == "7.3" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi
-  - if [ "$TRAVIS_PHP_VERSION" == "7.3" ]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi
+  - |
+      if [[ $DEFAULT == 1 && $TRAVIS_PHP_VERSION == "7.3" ]]; then
+        wget https://scrutinizer-ci.com/ocular.phar
+        php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+      fi
+
+notifications:
+  email: false

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,4 @@
+parameters:
+    level: 4
+    ignoreErrors:
+        - '#should return SocialConnect\\Common\\Entity\\User but returns object#'

--- a/src/OAuth2/Provider/Vimeo.php
+++ b/src/OAuth2/Provider/Vimeo.php
@@ -73,8 +73,10 @@ class Vimeo extends \SocialConnect\OAuth2\AbstractProvider
                     'name' => 'fullname',
                 ]);
 
-                $this->user = $hydrator->hydrate(new User(), $response['user']);
-                $this->user->id = str_replace('/users/', '', $this['user']['uri']);
+                /** @var \SocialConnect\Common\Entity\User $user */
+                $user = $hydrator->hydrate(new User(), $response['user']);
+                $this->user = $user;
+                $this->user->id = str_replace('/users/', '', $response['user']['uri']);
 
                 $token->setUserId((string) $this->user->id);
             }

--- a/src/OpenID/AbstractProvider.php
+++ b/src/OpenID/AbstractProvider.php
@@ -72,7 +72,7 @@ abstract class AbstractProvider extends AbstractBaseProvider
         $xml = new \SimpleXMLElement($response->getBody()->getContents());
 
         $this->version = 2;
-        $this->loginEntrypoint = $xml->XRD->Service->URI;
+        $this->loginEntrypoint = (string)$xml->XRD->Service->URI;
 
         return $this->getOpenIdUrl();
     }


### PR DESCRIPTION
Hey!

Type: code quality

For all OAuth1 providers error as below is shown for `getIdentity()` method:
```
Property SocialConnect\OAuth1\AbstractProvider::$consumerToken (SocialConnect\OAuth1\Token) does not accept SocialConnect\Provider\AccessTokenInterface.
```

for statement

```
$this->consumerToken = $accessToken;
```

That's a valid error since `SocialConnect\OAuth1\AbstractProvider::$consumerToken` property is supposed to be an `SocialAuth\OAuth1\Token` instance which does not extend the `AccessTokenInterface`.

I leave it to you to do the needful to fix it :slightly_smiling_face:.