### PR TITLE
Replace get/setSex with get/setGender

### DIFF
--- a/src/Common/Entity/User.php
+++ b/src/Common/Entity/User.php
@@ -53,7 +53,7 @@ class User extends \stdClass
      *
      * @var string
      */
-    protected $gender = GENDER_UNKNOWN;
+    protected $gender = self::GENDER_UNKNOWN;
 
     /**
      * @var string|null
@@ -95,11 +95,11 @@ class User extends \stdClass
     public function setGender(string $gender): void
     {
         $genders = [
-            GENDER_OTHER,
-            GENDER_MALE,
-            GENDER_FEMALE,
+            self::GENDER_OTHER,
+            self::GENDER_MALE,
+            self::GENDER_FEMALE,
         ];
-        if (! $gender in_array($genders)) {
+        if (! in_array($gender, $genders)) {
             throw new \InvalidArgumentException('Argument $gender is not valid');
         }
 

--- a/src/Common/Entity/User.php
+++ b/src/Common/Entity/User.php
@@ -8,8 +8,10 @@ namespace SocialConnect\Common\Entity;
 
 class User extends \stdClass
 {
-    const SEX_MALE = 'male';
-    const SEX_FEMALE = 'female';
+    const GENDER_MALE = 'male';
+    const GENDER_FEMALE = 'female';
+    const GENDER_OTHER = 'other';
+    const GENDER_UNKNOWN = 'unknown';
 
     /**
      * @var string
@@ -47,11 +49,11 @@ class User extends \stdClass
     public $username;
 
     /**
-     * Should be female or male
+     * One of the GENDER_-constants
      *
-     * @var string|null
+     * @var string
      */
-    protected $sex;
+    protected $gender = GENDER_UNKNOWN;
 
     /**
      * @var string|null
@@ -80,22 +82,43 @@ class User extends \stdClass
     }
 
     /**
-     * @return string|null
+     * @return string
      */
-    public function getSex(): ?string
+    public function getGender(): string
     {
-        return $this->sex;
+        return $this->gender;
     }
 
     /**
      * @param string $sex
      */
-    public function setSex(string $sex): void
+    public function setGender(string $gender): void
     {
-        if ($sex !== self::SEX_MALE && $sex !== self::SEX_FEMALE) {
-            throw new \InvalidArgumentException('Argument $sex is not valid');
+        $genders = [
+            GENDER_OTHER,
+            GENDER_MALE,
+            GENDER_FEMALE,
+        ];
+        if (! $gender in_array($genders)) {
+            throw new \InvalidArgumentException('Argument $gender is not valid');
         }
 
-        $this->sex = $sex;
+        $this->gender = $gender;
+    }
+    
+    /**
+     * @deprecated use `getGender` instead
+     */
+    public function getSex() : string
+    {
+        return $this->getGender();
+    }
+    
+    /**
+     * @deprecated Use setGender instead
+     */
+    public function setSex(string $sex) : void
+    {
+        $this->setGender($sex);
     }
 }

--- a/src/Common/Entity/User.php
+++ b/src/Common/Entity/User.php
@@ -8,6 +8,16 @@ namespace SocialConnect\Common\Entity;
 
 class User extends \stdClass
 {
+    /**
+     * @deprecated Use GENDER_MALE instead!
+     */
+    const SEX_MALE = 'male';
+    
+    /**
+     * @deprecated Use GENDER_FEMALE instead!
+     */
+    const SEX_FEMALE = 'female';
+    
     const GENDER_MALE = 'male';
     const GENDER_FEMALE = 'female';
     const GENDER_OTHER = 'other';

--- a/src/Common/Entity/User.php
+++ b/src/Common/Entity/User.php
@@ -121,6 +121,7 @@ class User extends \stdClass
      */
     public function getSex() : string
     {
+        trigger_error('getSex is deprecated. Use getGender instead', E_USER_DEPRECATED);
         return $this->getGender();
     }
     
@@ -129,6 +130,7 @@ class User extends \stdClass
      */
     public function setSex(string $sex) : void
     {
+        trigger_error('setSex is deprecated. Use setGender instead', E_USER_DEPRECATED);
         $this->setGender($sex);
     }
 }

--- a/src/Common/Entity/User.php
+++ b/src/Common/Entity/User.php
@@ -11,12 +11,12 @@ class User extends \stdClass
     /**
      * @deprecated Use GENDER_MALE instead!
      */
-    const SEX_MALE = 'male';
+    const SEX_MALE = 'male_deprecated';
     
     /**
      * @deprecated Use GENDER_FEMALE instead!
      */
-    const SEX_FEMALE = 'female';
+    const SEX_FEMALE = 'female_deprecated';
     
     const GENDER_MALE = 'male';
     const GENDER_FEMALE = 'female';
@@ -104,6 +104,16 @@ class User extends \stdClass
      */
     public function setGender(string $gender): void
     {
+        if ($gender === self::SEX_MALE) {
+            trigger_error ('the constant SEX_MALE is deprecated. use GENDER_MALE instead', E_USER_DEPRECATED);
+            $gender = self::GENDER_MALE;
+        }
+        
+        if ($gender === self::SEX_FEMALE) {
+            trigger_error ('the constant SEX_FEMALE is deprecated. use GENDER_FEMALE instead', E_USER_DEPRECATED);
+            $gender = self::GENDER_FEMALE;
+        }
+            
         $genders = [
             self::GENDER_OTHER,
             self::GENDER_MALE,

--- a/src/Common/Entity/User.php
+++ b/src/Common/Entity/User.php
@@ -99,9 +99,6 @@ class User extends \stdClass
         return $this->gender;
     }
 
-    /**
-     * @param string $sex
-     */
     public function setGender(string $gender): void
     {
         if ($gender === self::SEX_MALE) {

--- a/src/Common/Entity/User.php
+++ b/src/Common/Entity/User.php
@@ -105,12 +105,12 @@ class User extends \stdClass
     public function setGender(string $gender): void
     {
         if ($gender === self::SEX_MALE) {
-            trigger_error ('the constant SEX_MALE is deprecated. use GENDER_MALE instead', E_USER_DEPRECATED);
+            trigger_error('the constant SEX_MALE is deprecated. use GENDER_MALE instead', E_USER_DEPRECATED);
             $gender = self::GENDER_MALE;
         }
         
         if ($gender === self::SEX_FEMALE) {
-            trigger_error ('the constant SEX_FEMALE is deprecated. use GENDER_FEMALE instead', E_USER_DEPRECATED);
+            trigger_error('the constant SEX_FEMALE is deprecated. use GENDER_FEMALE instead', E_USER_DEPRECATED);
             $gender = self::GENDER_FEMALE;
         }
             

--- a/src/OAuth2/Provider/Facebook.php
+++ b/src/OAuth2/Provider/Facebook.php
@@ -60,7 +60,18 @@ class Facebook extends \SocialConnect\OAuth2\AbstractProvider
             'last_name' => 'lastname',
             'email' => 'email',
             'gender' => static function ($value, User $user) {
-                $user->setSex($value === 1 ? User::SEX_FEMALE : User::SEX_MALE);
+                switch ($value) {
+                    case 'male':
+                        $gender = User::GENDER_MALE;
+                        break;
+                    case 'female':
+                        $gender = User::GENDER_FEMALE;
+                        break;
+                    default:
+                        $gender = User::GENDER_OTHER;
+                        break;
+                }
+                $user->setGender($gender);
             },
             'link' => 'url',
             'locale' => 'locale',

--- a/src/OAuth2/Provider/Google.php
+++ b/src/OAuth2/Provider/Google.php
@@ -84,7 +84,7 @@ class Google extends AbstractProvider
             'verified_email' => 'emailVerified',
             'name' => 'fullname',
             'gender' => static function ($value, User $user) {
-                $user->setSex($value);
+                $user->setGender($value);
             },
             'picture' => 'pictureURL'
         ]);

--- a/src/OAuth2/Provider/MailRu.php
+++ b/src/OAuth2/Provider/MailRu.php
@@ -121,7 +121,7 @@ class MailRu extends \SocialConnect\OAuth2\AbstractProvider
             'nick' => 'username',
             'pic_big' => 'pictureURL',
             'sex' => static function ($value, User $user) {
-                $user->setSex($value === 1 ? User::SEX_FEMALE : User::SEX_MALE);
+                $user->setGender($value === 1 ? User::GENDER_FEMALE : User::GENDER_MALE);
             }
         ]);
 

--- a/src/OAuth2/Provider/Meetup.php
+++ b/src/OAuth2/Provider/Meetup.php
@@ -72,7 +72,7 @@ class Meetup extends \SocialConnect\OAuth2\AbstractProvider
             'username' => 'name',
             'fullname' => 'name',
             'sex' => static function ($value, User $user) {
-                $user->setSex($value);
+                $user->setGender($value);
             },
             'photo.photo_link' => 'pictureURL'
         ]);

--- a/src/OAuth2/Provider/Vk.php
+++ b/src/OAuth2/Provider/Vk.php
@@ -84,7 +84,7 @@ class Vk extends \SocialConnect\OAuth2\AbstractProvider
                 );
             },
             'sex' => static function ($value, User $user) {
-                $user->setSex($value === 1 ? User::SEX_FEMALE : User::SEX_MALE);
+                $user->setGender($value === 1 ? User::GENDER_FEMALE : User::GENDER_MALE);
             },
             'screen_name' => 'username',
             'photo_max_orig' => 'pictureURL',

--- a/src/OpenIDConnect/Provider/Google.php
+++ b/src/OpenIDConnect/Provider/Google.php
@@ -72,7 +72,7 @@ class Google extends AbstractProvider
             'verified_email' => 'emailVerified',
             'name' => 'fullname',
             'gender' => static function ($value, User $user) {
-                $user->setSex($value);
+                $user->setGender($value);
             },
         ]);
 

--- a/tests/Test/Common/ArrayHydratorTest.php
+++ b/tests/Test/Common/ArrayHydratorTest.php
@@ -16,7 +16,7 @@ class ArrayHydratorTest extends AbstractProviderTestCase
         $hydrator = new ArrayHydrator([
             'firstname' => 'firstname',
             'sex' => static function ($value, User $user) {
-                $user->setSex($value);
+                $user->setGender($value);
             },
             'image.picture' => 'pictureURL',
         ]);
@@ -32,6 +32,6 @@ class ArrayHydratorTest extends AbstractProviderTestCase
 
         parent::assertEquals($expectedFirstName, $user->firstname);
         parent::assertEquals($expectedPictureUrl, $user->pictureURL);
-        parent::assertEquals($expectedSex, $user->getSex());
+        parent::assertEquals($expectedSex, $user->getGender());
     }
 }

--- a/tests/Test/OAuth2/Provider/VkTest.php
+++ b/tests/Test/OAuth2/Provider/VkTest.php
@@ -48,7 +48,7 @@ class VkTest extends AbstractProviderTestCase
         parent::assertSame($expectedId, $result->id);
         parent::assertSame($expectedFirstname, $result->firstname);
         parent::assertSame($expectedLastname, $result->lastname);
-        parent::assertSame('female', $result->getSex());
+        parent::assertSame('female', $result->getGender());
     }
 
     /**


### PR DESCRIPTION
As explained in #94 it's a good idea to use gender instead of sex. 

To not break BC the get/setSex are still available but are marked as deprecated. The current functionality works as before. In addition to that it is possible to set `other` as gender and the default now is to return `unknown` instead of NULL.