### PR TITLE
Twitter: Added Email to ArrayHydrator object

### DIFF
--- a/src/OAuth1/Provider/Twitter.php
+++ b/src/OAuth1/Provider/Twitter.php
@@ -60,6 +60,7 @@ class Twitter extends \SocialConnect\OAuth1\AbstractProvider
         $hydrator = new ArrayHydrator([
             'id' => 'id',
             'name' => 'fullname',
+            'email' => 'email',
             'screen_name' => 'username',
             'profile_image_url_https' => 'pictureURL'
         ]);


### PR DESCRIPTION
Hey!

Type: bug fix

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/SocialConnect/auth/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

Twitter Provider was missing the email key, as such even if the app has email permission it would report the email as null.

Thanks :smiley_cat:
