### PR TITLE
reference simple-cache properly in Common composer.json

### DIFF
--- a/src/Common/composer.json
+++ b/src/Common/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "php": ">=7.1",
-        "simple-cache": "^1.0"
+        "psr/simple-cache": "^1.0"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
`simple-cache` is a psr package. It's correctly referenced in the base `composer.json` but not in Common.