### PR TITLE
update diactoros package in examples composer.json

### DIFF
--- a/example/composer.json
+++ b/example/composer.json
@@ -9,7 +9,7 @@
         "symfony/cache": "^4.3",
         "php-http/guzzle6-adapter": "^2.0",
         "guzzlehttp/psr7": "^1.6",
-        "zendframework/zend-diactoros": "^2.1",
+        "laminas/laminas-diactoros": "^2.1",
         "socialconnect/http-client": "^1.0"
     },
     "license": "MIT",


### PR DESCRIPTION
zendframework/zend-diactoros has moved to laminas/laminas-diactoros and the original repository is abandoned