### PR TITLE
Refresh access_token request added

### DIFF
--- a/tests/Test/OpenIDConnect/Provider/AppleTest.php
+++ b/tests/Test/OpenIDConnect/Provider/AppleTest.php
@@ -31,7 +31,7 @@ class AppleTest extends AbstractProviderTestCase
 
     public function testGetOpenIDUrl()
     {
-        // nothing to test, because Apple->testGetOpenIDUrl will throw an exception on call
+        $this->markTestSkipped('nothing to test, because Apple->testGetOpenIDUrl will throw an exception on call');
     }
 
     public function testGetIdentitySuccess()


### PR DESCRIPTION
Hey!

Type: new feature

- [x] I have read and understood the [Contributing Guidelines](https://github.com/SocialConnect/auth/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

added request to refresh an access_token with an refresh_token.

Thanks :smiley_cat:
