### PR TITLE
Bump up phpstan version and fix reported errors.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,4 @@ tests export-ignore
 .scrutinizer.yml export-ignore
 phpunit.xml.dist export-ignore
 phpmd.xml.dist export-ignore
+phpstan.neon export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           php-version: '7.4'
           coverage: none
-          tools: cs2pr
+          tools: cs2pr, phpstan:1.6
 
       - name: Composer Install
         run: composer install
@@ -68,4 +68,4 @@ jobs:
 
       - name: Run phpstan
         if: success() || failure()
-        run: vendor/bin/phpstan.phar analyse src/ tests/ --no-progress --level 2
+        run: phpstan

--- a/composer.json
+++ b/composer.json
@@ -36,8 +36,7 @@
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.3.2",
         "phpunit/phpunit": "^7.5",
-        "socialconnect/http-client": "^1.0",
-        "phpstan/phpstan-shim": "^0.11.12"
+        "socialconnect/http-client": "^1.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,4 @@
+parameters:
+	level: 5
+	paths:
+		- src/

--- a/src/OAuth1/Provider/Atlassian.php
+++ b/src/OAuth1/Provider/Atlassian.php
@@ -104,11 +104,9 @@ class Atlassian extends AbstractProvider
      */
     public function getIdentity(AccessTokenInterface $accessToken)
     {
-        $this->consumerToken = $accessToken;
-
         $parameters = [
             'oauth_consumer_key' => $this->consumer->getKey(),
-            'oauth_token' => $this->consumerToken->getToken(),
+            'oauth_token' => $accessToken->getToken(),
         ];
 
         $response = $this->oauthRequest(

--- a/src/OAuth1/Provider/Px500.php
+++ b/src/OAuth1/Provider/Px500.php
@@ -63,8 +63,6 @@ class Px500 extends AbstractProvider
      */
     public function getIdentity(AccessTokenInterface $accessToken)
     {
-        $this->consumerToken = $accessToken;
-
         $result = $this->request(
             'GET',
             'users',

--- a/src/OAuth1/Provider/Trello.php
+++ b/src/OAuth1/Provider/Trello.php
@@ -62,8 +62,6 @@ class Trello extends AbstractProvider
      */
     public function getIdentity(AccessTokenInterface $accessToken)
     {
-        $this->consumerToken = $accessToken;
-
         $parameters = [
             'key' => $this->consumer->getKey(),
             'token' => $accessToken->getToken()

--- a/src/OAuth1/Provider/Tumblr.php
+++ b/src/OAuth1/Provider/Tumblr.php
@@ -63,8 +63,6 @@ class Tumblr extends AbstractProvider
      */
     public function getIdentity(AccessTokenInterface $accessToken)
     {
-        $this->consumerToken = $accessToken;
-
         $result = $this->request(
             'GET',
             'user/info',

--- a/src/OAuth1/Provider/Twitter.php
+++ b/src/OAuth1/Provider/Twitter.php
@@ -45,8 +45,6 @@ class Twitter extends \SocialConnect\OAuth1\AbstractProvider
      */
     public function getIdentity(AccessTokenInterface $accessToken)
     {
-        $this->consumerToken = $accessToken;
-
         $result = $this->request(
             'GET',
             'account/verify_credentials.json',

--- a/src/OAuth1/Signature/MethodRSASHA1.php
+++ b/src/OAuth1/Signature/MethodRSASHA1.php
@@ -53,6 +53,7 @@ class MethodRSASHA1 extends AbstractSignatureMethod
     public function buildSignature(string $signatureBase, Consumer $consumer, Token $token)
     {
         $certificate = openssl_pkey_get_private('file://' . $this->privateKey);
+        /** @phpstan-ignore-next-line */
         $privateKeyId = openssl_pkey_get_private($certificate);
 
         $signature = null;

--- a/src/OpenID/AbstractProvider.php
+++ b/src/OpenID/AbstractProvider.php
@@ -73,7 +73,7 @@ abstract class AbstractProvider extends AbstractBaseProvider
         $xml = new \SimpleXMLElement($response->getBody()->getContents());
 
         $this->version = 2;
-        $this->loginEntrypoint = $xml->XRD->Service->URI;
+        $this->loginEntrypoint = (string)$xml->XRD->Service->URI;
 
         return $this->getOpenIdUrl();
     }

--- a/src/Provider/AbstractBaseProvider.php
+++ b/src/Provider/AbstractBaseProvider.php
@@ -372,7 +372,7 @@ abstract class AbstractBaseProvider
                 $contentLength = mb_strlen($payloadAsString);
 
                 $request = $request
-                    ->withHeader('Content-Length', $contentLength)
+                    ->withHeader('Content-Length', (string)$contentLength)
                     ->withHeader('Content-Type', 'application/x-www-form-urlencoded')
                 ;
 

--- a/tests/Test/Provider/ProviderMock.php
+++ b/tests/Test/Provider/ProviderMock.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
 
 namespace Test\Provider;
 
+use SocialConnect\Common\Entity\User;
 use SocialConnect\Provider\AbstractBaseProvider;
 use SocialConnect\Provider\AccessTokenInterface;
 
@@ -17,6 +18,7 @@ class ProviderMock extends AbstractBaseProvider
     public function getBaseUri()
     {
         // TODO: Implement getBaseUri() method.
+        return '';
     }
 
     /**
@@ -58,6 +60,7 @@ class ProviderMock extends AbstractBaseProvider
     public function getIdentity(AccessTokenInterface $accessToken)
     {
         // TODO: Implement getIdentity() method.
+        return new User();
     }
 
     /**


### PR DESCRIPTION
Hey!

Type: code quality

@ovr Please confirm that the removal of `$this->consumerToken = $accessToken;` statement from OAuth1 providers is okay. phpstan was throwing error like 
```
Property SocialConnect\OAuth1\AbstractProvider::$consumerToken (SocialConnect\OAuth1\Token) does not accept SocialConnect\Provider\AccessTokenInterface.
``` 
for those statements.