### PR TITLE
Remove superfluous annotation.

### DIFF
--- a/src/Auth/Service.php
+++ b/src/Auth/Service.php
@@ -38,7 +38,6 @@ class Service
      * @param SessionInterface $session
      * @param array $config
      * @param FactoryInterface|null $factory
-     * @internal param $storage
      */
     public function __construct(HttpStack $httpStack, SessionInterface $session, array $config, FactoryInterface $factory = null)
     {


### PR DESCRIPTION
It's causing static analyzers like psalm to complain about use of internal class which this class isn't.


Hey!

Type: code quality | documentation

Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [ ] I have read and understood the [Contributing Guidelines](https://github.com/SocialConnect/auth/blob/master/.github/CONTRIBUTING.md).
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

Thanks :smiley_cat:
