### PR TITLE
#155

### DIFF
--- a/src/OAuth2/Provider/GitLab.php
+++ b/src/OAuth2/Provider/GitLab.php
@@ -63,8 +63,9 @@ class GitLab extends \SocialConnect\OAuth2\AbstractProvider
         $response = $this->request('GET', 'user', [], $accessToken);
 
         $hydrator = new ArrayHydrator([
-            'user_id' => 'id',
+            'id' => 'id',
             'name' => 'fullname',
+            'username' => 'username',
             'avatar_url' => 'pictureURL'
         ]);
 


### PR DESCRIPTION
- updated fieldmapping for userId for the OAuth2 GitLab Provider
- added username field for the OAuth2 GitLab Provider


Hey!

Type: bug fix 

Link to issue:
#155 

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/SocialConnect/auth/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:
- updated fieldmapping for userId for the OAuth2 GitLab Provider
- added username field for the OAuth2 GitLab Provider
Thanks :smiley_cat:
