### PR TITLE
Documentation: Add keycloak to list of oidc providers

### DIFF
--- a/docs/openid-connect.md
+++ b/docs/openid-connect.md
@@ -37,3 +37,4 @@ Library has built in support for the following providers:
 | PixelIn                         |              |
 | Apple                           |              |
 | AzureAD                         |              |
+| Keycloak                        |              |


### PR DESCRIPTION
Hey!

Type: documentation


- [x] I have read and understood the [Contributing Guidelines](https://github.com/SocialConnect/auth/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

Just a simple documentation change (to make it more obvious that keycloak is also supported as an oidc provider).