### PR TITLE
Fix email on Hydrator

### DIFF
--- a/src/OAuth2/Provider/Discord.php
+++ b/src/OAuth2/Provider/Discord.php
@@ -76,7 +76,7 @@ class Discord extends \SocialConnect\OAuth2\AbstractProvider
             'id' => 'id',
             'username' => 'username',
             'avatar' => 'pictureURL',
-            'mail' => 'email',
+            'email' => 'email',
             'verified' => 'emailVerified'
         ]);
 


### PR DESCRIPTION
Hey!

Type: bug fix

Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/SocialConnect/auth/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

Fix email name for get email on api response
