### PR TITLE
Fix broken link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Code examples you can find in [example](./example) directory
 * <b>Functional</b>: support [30+ providers]((https://socialconnect.lowl.io/providers.html)) such as Facebook, Google, Twitter, GitHub, Vk and another.
 * <b>Completely</b>: We supports all social sign standarts: OAuth1/OAuth2/OpenID/OpenIDConnect.
 * <b>Follow standards</b>: We follow PSR-7/PSR-17/PSR-18 standards.
-* <b>Modular</b>: Use only what, that you need, see [architecture overview](http://localhost:4000/architecture.html).
+* <b>Modular</b>: Use only what, that you need, see [architecture overview](https://socialconnect.lowl.io/architecture.html).
 * <b>Quality</b>: CodeCoverage with 80%+ and We are using static analyzers.
 
 ## Supported type of providers


### PR DESCRIPTION
Type: documentation

Link to issue: -

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/SocialConnect/auth/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

Fix broken link to architecture documentation
