### PR TITLE
fix : psr/simple-cache ^2.0 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "php": ">=7.1",
         "ext-json": "*",
         "psr/http-client": "^1.0",
-        "psr/simple-cache": "^1.0",
+        "psr/simple-cache": "^1.0 || ^2.0",
         "psr/http-factory": "^1.0",
         "socialconnect/jwx": "^1.0"
     },


### PR DESCRIPTION
Hey!

Type: bug fix

Link to issue: [#172](https://github.com/SocialConnect/auth/issues/172)

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [Contributing Guidelines](https://github.com/SocialConnect/auth/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [] I wrote some tests for this PR.

The test result errors exists previously on master:

There was 1 error:
1) Test\OpenID\Provider\SteamTest::testGetAccessTokenByRequestParametersSuccess
SocialConnect\OpenID\Exception\Unauthorized: Timestamp from nonce is older then time() + 60s
%~dp0\auth\src\OpenID\AbstractProvider.php:148
%~dp0\auth\src\OpenID\AbstractProvider.php:165
%~dp0\auth\tests\Test\OpenID\Provider\AbstractProviderTestCase.php:146
phpvfscomposer://%~dp0\auth\vendor\phpunit\phpunit\phpunit:60
--

There was 1 risky test:
1) Test\OpenIDConnect\Provider\AppleTest::testGetOpenIDUrl
This test did not perform any assertions
%~dp0\auth\tests\Test\OpenIDConnect\Provider\AppleTest.php:32
phpvfscomposer://%~dp0\auth\vendor\phpunit\phpunit\phpunit:60

Small description of change:
Update dependency psr/simple-cache to version 2.0 in order to SocialConnect/Auth to be installed in CakePhp V 4.x

Thanks :smiley_cat:
