### PR TITLE
Update AbstractProvider.php

### DIFF
--- a/src/OAuth1/AbstractProvider.php
+++ b/src/OAuth1/AbstractProvider.php
@@ -107,7 +107,7 @@ abstract class AbstractProvider extends AbstractBaseProvider
         );
 
         $token = $this->parseToken($response->getBody()->getContents());
-        $this->session->set('oauth1_request_token', $token);
+        $this->session->set('oauth1_request_token', serialize($token));
 
         return $token;
     }
@@ -270,7 +270,7 @@ abstract class AbstractProvider extends AbstractBaseProvider
             throw new Unauthorized('Unknown oauth_verifier');
         }
 
-        return $this->getAccessToken($token, $parameters['oauth_verifier']);
+        return $this->getAccessToken(unserialize($token), $parameters['oauth_verifier']);
     }
 
     /**


### PR DESCRIPTION
Hey!

Type: bug fix 

Link to issue: [https://github.com/SocialConnect/auth/issues/177#issue-1243331865](https://github.com/SocialConnect/auth/issues/177#issue-1243331865)

**In raising this pull request, I confirm the following (please check boxes):**

- [] I have read and understood the [Contributing Guidelines](https://github.com/SocialConnect/auth/blob/master/.github/CONTRIBUTING.md).
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change: Error fix
Fatal error: Uncaught TypeError: Argument 1 passed to SocialConnect\OAuth1\AbstractProvider::getAccessToken() must be an instance of SocialConnect\OAuth1\Token, instance of __PHP_Incomplete_Class given, called in /var/www//system/library/social/vendor/socialconnect/auth/src/OAuth1/AbstractProvider.php

Thanks :smiley_cat:
