### PR TITLE
Add support for psr/simple-cache:^3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "php": ">=7.1",
         "ext-json": "*",
         "psr/http-client": "^1.0 || ^2.0",
-        "psr/simple-cache": "^1.0 || ^2.0",
+        "psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
         "psr/http-factory": "^1.0 || ^2.0",
         "socialconnect/jwx": "^1.0"
     },


### PR DESCRIPTION
Hey!

Type: new feature

Link to issue: n/a

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/SocialConnect/auth/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:
Added `|| ^3.0` to the `psr/simple-cache` version constraint.

Thanks :smiley_cat:
