### PR TITLE
Fix use of deprecated string interpolation

### DIFF
--- a/src/OpenID/AbstractProvider.php
+++ b/src/OpenID/AbstractProvider.php
@@ -100,7 +100,7 @@ abstract class AbstractProvider extends AbstractBaseProvider
             return $requestParameters[$key];
         }
 
-        throw new Unauthorized("There is no required parameter called: '${key}'");
+        throw new Unauthorized("There is no required parameter called: '{$key}'");
     }
 
     /**


### PR DESCRIPTION
Hey!

Type: code quality

- [x] I have read and understood the [Contributing Guidelines](https://github.com/SocialConnect/auth/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.


PHP 8.1 deprecates the `${}` string interpolation. 

Thanks :smiley_cat:
