### PR TITLE
add a getter for id_token for OpenID Connect

### DIFF
--- a/src/OpenIDConnect/AccessToken.php
+++ b/src/OpenIDConnect/AccessToken.php
@@ -18,6 +18,11 @@ class AccessToken extends \SocialConnect\OAuth2\AccessToken
     protected $jwt;
 
     /**
+     * @var string
+     */
+    protected $idToken;
+
+    /**
      * @param array $token
      * @throws InvalidAccessToken
      */
@@ -28,6 +33,8 @@ class AccessToken extends \SocialConnect\OAuth2\AccessToken
         if (!isset($token['id_token'])) {
             throw new InvalidAccessToken('id_token doesnot exists inside AccessToken');
         }
+
+        $this->idToken = $token['id_token'];
     }
 
     /**
@@ -50,5 +57,13 @@ class AccessToken extends \SocialConnect\OAuth2\AccessToken
         }
 
         $this->jwt = $jwt;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIdToken()
+    {
+        return $this->idToken;
     }
 }

--- a/tests/Test/OpenIDConnect/AccessTokenTest.php
+++ b/tests/Test/OpenIDConnect/AccessTokenTest.php
@@ -17,19 +17,21 @@ class AccessTokenTest extends AbstractTestCase
         $expectedToken = "XSFJSKLFJDLKFJDLSJFLDSJFDSLFSD";
         $expectedExpires = time();
         $expectedUserId = 123456789;
+        $expectedIdToken = 'test';
 
         $token = new AccessToken(
             [
                 'access_token' => $expectedToken,
                 'expires' => $expectedExpires,
                 'user_id' => $expectedUserId,
-                'id_token' => 'test'
+                'id_token' => $expectedIdToken,
             ]
         );
 
         $this->assertSame($expectedToken, $token->getToken());
         $this->assertSame((string) $expectedUserId, $token->getUserId());
         $this->assertSame($expectedExpires, $token->getExpires());
+        $this->assertSame($expectedIdToken, $token->getIdToken());
 
         return $token;
     }


### PR DESCRIPTION
Type: new feature

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/SocialConnect/auth/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: Adds a getter for `id_token` when using OpenID connect.

When using 'RP-Initiated Logout' in OpenID, the RP can redirect the user to the Identity Provider and provide a `id_token_hint` which is meant to equal a previously issued `id_token`. [Spec](https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout). But when using this library, the `id_token` is parsed and the original id_token string is discarded [here](https://github.com/SocialConnect/auth/blob/75326deee46d0646d521419fa34719fe013c1501/src/OpenIDConnect/AbstractProvider.php#L89-L106). Only the parsed JWT is left over, and it doesn't seem possible to reconstruct the `id_token` string from the `JWT` class. So this PR saves the `id_token` string in `AccessToken` and provides a getter for it.