### PR TITLE
Correct spelling and grammar in error messages

### DIFF
--- a/src/OpenID/AbstractProvider.php
+++ b/src/OpenID/AbstractProvider.php
@@ -220,6 +220,6 @@ abstract class AbstractProvider extends AbstractBaseProvider
      */
     public function createAccessToken(array $information)
     {
-        throw new Unsupported('It\'s usefull to use this method for OpenID, are you sure?');
+        throw new Unsupported('It\'s useful to use this method for OpenID, are you sure?');
     }
 }

--- a/src/OpenIDConnect/AccessToken.php
+++ b/src/OpenIDConnect/AccessToken.php
@@ -26,7 +26,7 @@ class AccessToken extends \SocialConnect\OAuth2\AccessToken
         parent::__construct($token);
 
         if (!isset($token['id_token'])) {
-            throw new InvalidAccessToken('id_token doesnot exists inside AccessToken');
+            throw new InvalidAccessToken('id_token does not exist inside AccessToken');
         }
     }
 

--- a/tests/Test/OpenIDConnect/AccessTokenTest.php
+++ b/tests/Test/OpenIDConnect/AccessTokenTest.php
@@ -37,7 +37,7 @@ class AccessTokenTest extends AbstractTestCase
     public function testConstructFailedWithNoIdKey()
     {
         $this->expectException(InvalidAccessToken::class);
-        $this->expectExceptionMessage('id_token doesnot exists inside AccessToken');
+        $this->expectExceptionMessage('id_token does not exist inside AccessToken');
 
         $expectedToken = "XSFJSKLFJDLKFJDLSJFLDSJFDSLFSD";
         $expectedExpires = time();


### PR DESCRIPTION
Howdy

Type: code quality

Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [Contributing Guidelines](https://github.com/SocialConnect/auth/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

Correct spelling and grammar in error messages in `src/OpenID/AbstractProvider.php` and `src/OpenIDConnect/AccessToken.php`.

Thank you!
:smiley_cat: 💯 🌸 
