### PR TITLE
Adjust Reddit provider for updated subdomains in URLs

### DIFF
--- a/src/OAuth2/Provider/Reddit.php
+++ b/src/OAuth2/Provider/Reddit.php
@@ -23,12 +23,12 @@ class Reddit extends \SocialConnect\OAuth2\AbstractProvider
 
     public function getAuthorizeUri()
     {
-        return 'https://ssl.reddit.com/api/v1/authorize';
+        return 'https://www.reddit.com/api/v1/authorize';
     }
 
     public function getRequestTokenUri()
     {
-        return 'https://ssl.reddit.com/api/v1/access_token';
+        return 'https://www.reddit.com/api/v1/access_token';
     }
 
     public function getName()


### PR DESCRIPTION
Hey!

Type: bug fix

Link to issue: N/A

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/SocialConnect/auth/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change: Reddit changed their subdomains and the old ones end up returning some 403 here and there.

Thanks :smiley_cat:
