### PR TITLE
Fix: generatePKCECodeVerifier length

### DIFF
--- a/src/OAuth2/AbstractProvider.php
+++ b/src/OAuth2/AbstractProvider.php
@@ -27,6 +27,8 @@ abstract class AbstractProvider extends AbstractBaseProvider
 
     protected bool $pkce = false;
 
+    protected int $pkceCodeVerifierLength = 96;
+
     /**
      * @return string
      */
@@ -50,7 +52,7 @@ abstract class AbstractProvider extends AbstractBaseProvider
         $parameters['response_type'] = 'code';
 
         if ($this->pkce) {
-            $codeVerifier = $this->generatePKCECodeVerifier();
+            $codeVerifier = $this->generatePKCECodeVerifier($this->pkceCodeVerifierLength);
             $this->session->set('code_verifier', $codeVerifier);
 
             $parameters['code_challenge'] = $this->generatePKCECodeChallenge($codeVerifier);
@@ -60,10 +62,12 @@ abstract class AbstractProvider extends AbstractBaseProvider
         return $parameters;
     }
 
-    private function generatePKCECodeVerifier(int $length = 128)
+    private function generatePKCECodeVerifier(int $length = 96): string
     {
-        if ($length < 43 || $length > 128) {
-            throw new \Exception("Length must be between 43 and 128");
+        if ($length < 32 || $length > 96) {
+            throw new \Exception(
+                "Final length must be between 43 and 128, so the number of random bytes must be between 32 and 96"
+            );
         }
 
         $randomBytes = random_bytes($length);
@@ -151,7 +155,7 @@ abstract class AbstractProvider extends AbstractBaseProvider
         return $this->httpStack->createRequest($this->requestHttpMethod, $this->getRequestTokenUri())
             ->withHeader('Content-Type', 'application/x-www-form-urlencoded')
             ->withBody($this->httpStack->createStream(http_build_query($parameters, '', '&')))
-        ;
+            ;
     }
 
     /**

--- a/src/OAuth2/AbstractProvider.php
+++ b/src/OAuth2/AbstractProvider.php
@@ -155,7 +155,7 @@ abstract class AbstractProvider extends AbstractBaseProvider
         return $this->httpStack->createRequest($this->requestHttpMethod, $this->getRequestTokenUri())
             ->withHeader('Content-Type', 'application/x-www-form-urlencoded')
             ->withBody($this->httpStack->createStream(http_build_query($parameters, '', '&')))
-            ;
+        ;
     }
 
     /**

--- a/src/OAuth2/AbstractProvider.php
+++ b/src/OAuth2/AbstractProvider.php
@@ -27,7 +27,7 @@ abstract class AbstractProvider extends AbstractBaseProvider
 
     protected bool $pkce = false;
 
-    protected int $pkceCodeVerifierLength = 96;
+    protected int $pkceCodeVerifierByteLength = 96;
 
     /**
      * @return string
@@ -52,7 +52,7 @@ abstract class AbstractProvider extends AbstractBaseProvider
         $parameters['response_type'] = 'code';
 
         if ($this->pkce) {
-            $codeVerifier = $this->generatePKCECodeVerifier($this->pkceCodeVerifierLength);
+            $codeVerifier = $this->generatePKCECodeVerifier($this->pkceCodeVerifierByteLength);
             $this->session->set('code_verifier', $codeVerifier);
 
             $parameters['code_challenge'] = $this->generatePKCECodeChallenge($codeVerifier);
@@ -62,15 +62,15 @@ abstract class AbstractProvider extends AbstractBaseProvider
         return $parameters;
     }
 
-    private function generatePKCECodeVerifier(int $length = 96): string
+    private function generatePKCECodeVerifier(int $byteLength = 96): string
     {
-        if ($length < 32 || $length > 96) {
+        if ($byteLength < 32 || $byteLength > 96) {
             throw new \Exception(
                 "Final length must be between 43 and 128, so the number of random bytes must be between 32 and 96"
             );
         }
 
-        $randomBytes = random_bytes($length);
+        $randomBytes = random_bytes($byteLength);
         return rtrim(strtr(base64_encode($randomBytes), '+/', '-_'), '=');
     }
 


### PR DESCRIPTION
Type: **bug fix** | ~~new feature~~ | ~~code quality~~ | ~~documentation~~

Link to issue: https://github.com/SocialConnect/auth/issues/198

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/SocialConnect/auth/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

- Fixes generatePKCECodeVerifier() to never generate strings < 43 or > 128 in length
- adds pkceCodeVerifierLength to customize the code_verifier length

Thanks :smiley_cat:
